### PR TITLE
Fix for ignored shouldCreateOpen options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -119,7 +119,7 @@ export default class FromTemplatePlugin extends Plugin {
 			const path =spec.settings.outputDirectory + "/" + filename + ".md" 
 			try {
 				fileOK = false
-				const file = await this.app.vault.create(path, filledTemplate)
+				newFile = await this.app.vault.create(path, filledTemplate)
 				fileOK = true
 			} catch (error) {
 				alert("Couldn't create file: " + filename + "\n" + error.toString() )


### PR DESCRIPTION
It seems that at some point the name of newFile and the actual file created during plugin execution got out of sync.  I removed the declaration (const) from the file creation, and changed the name back to newFile, effectively repointing the null reference, which is what the downstream code is looking for in lines 138 through 142.